### PR TITLE
Supporting C++11

### DIFF
--- a/source/HelloWorld.cpp
+++ b/source/HelloWorld.cpp
@@ -33,7 +33,8 @@ void onButtonA(MicroBitEvent)
 
 void onButtonB(MicroBitEvent)
 {
-    uBit.display.scroll("DARYL");
+    auto str = "DARYL";
+    uBit.display.scroll(str);
 }
 
 int main()


### PR DESCRIPTION
Hi Joe,

The C++ layers in PXT use C++11 features.  Would it be an easy change to have the nrf51dk-DAL target support C++11?

Here's a sample of the errors I get:

```
/Users/darzu/microbit/nrf51dk-samples/source/HelloWorld.cpp:36:5: warning: 'auto' changes meaning in C++11; please remove it [-Wc++0x-compat]
     auto str = "DARYL";
     ^
/Users/darzu/microbit/nrf51dk-samples/source/HelloWorld.cpp:36:10: error: 'str' does not name a type
     auto str = "DARYL";
          ^
/Users/darzu/microbit/nrf51dk-samples/source/HelloWorld.cpp:37:25: error: 'str' was not declared in this scope
     uBit.display.scroll(str);
                         ^
```

Cheers,
Daryl
